### PR TITLE
[BUG-FIXED] Reset Functionality for Practice Questions and Lessons

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,6 +1,7 @@
 let editor;
 let pyodide;
 let currentLesson;
+let currentContentType; 
 
 // Add these lines at the beginning of the file
 let userProgress = JSON.parse(localStorage.getItem('userProgress')) || {
@@ -76,6 +77,7 @@ window.addEventListener('load', initPyodide);
 
 function showEditor(lesson) {
     currentLesson = lesson;
+    currentContentType = 'lesson';  // Set the content type to 'lesson'
     document.getElementById('editor-container').style.display = 'flex';
     if (!editor) {
         editor = ace.edit("editor");
@@ -425,11 +427,14 @@ const questions = [
     "Write a Python function to sort a list of numbers."
     // Add more questions as needed
 ];
-
 function generateQuestion() {
+    currentContentType = 'practice_question';
     const randomIndex = Math.floor(Math.random() * questions.length);
-    const randomQuestion = questions[randomIndex];
-    document.getElementById('random-question').innerText = randomQuestion;
+    currentContent = questions[randomIndex]; // Store the current question text
+    document.getElementById('random-question').innerText = currentContent;
+    if (editor) {
+        editor.setValue(`# Question: ${currentContent}\n\n# Write your Python code here:\n`, 1);
+    }
 }
 
 // Call this function on page load if you want to display a question initially
@@ -631,13 +636,25 @@ hamburger.addEventListener("click", () => {
     updateProgressBar();
 });
 
+//This function should check currentContentType to decide how to reset the editor.
+function resetEditor() {
+    // Check the type of content currently loaded
+    if (currentContentType === 'lesson') {
+        // If it's a lesson, reset to the original lesson content
+        showEditor(currentLesson);
+    } else if (currentContentType === 'practice_question') {
+        // If it's a practice question, clear the editor but keep the question visible
+        if (editor && currentContent) {
+            editor.setValue(`# Question: ${currentContent}\n\n# Write your Python code here:\n`, 1);
+        }
+    }
+}
 
-// Reset button 
-document.getElementById('reset-code').addEventListener('click', () => {
-    if (currentLesson) {
-        showEditor(currentLesson); 
-    } 
+//reset-button
+document.addEventListener('DOMContentLoaded', function() {
+    document.getElementById('reset-code').addEventListener('click', resetEditor);
 });
+
 
 document.getElementById('copy-code').addEventListener('click', () => {
     const code = editor.getValue();


### PR DESCRIPTION
**Related Issue:** Fixes Issue #78 

**Summary of Changes:**
This PR introduces enhancements to the reset functionality of the editor in the Math 4 Python learning platform. The changes ensure that when users press the reset button while working on practice questions, the editor clears any written code but retains the question text as a comment. This allows users to restart their solution without losing the context of the question. Additionally, the reset functionality for lessons remains intact, reloading the initial content and setup for the given lesson.

**Key Enhancements:**
1. **Persistent Question Display:** Practice questions remain visible in the editor as comments, allowing users to refer back to the question without navigating away from the editor.
2. **Clear Separation of Code and Content:** Ensures a clear workspace by only clearing user input and not the instructional content or questions.
3. **State Management:** Improved state management to distinguish between lessons and practice questions, ensuring appropriate behavior of the reset button depending on the context.

### Implementation Details:
- Introduced a new variable `currentContentType` to track whether the editor is displaying a lesson or a practice question.
- Modified the `resetEditor` function to clear the editor's content without reloading the practice question.
- Updated the `generateQuestion` function to store the current question as `currentContent` and ensure it is displayed as a comment in the editor upon reset.

### Testing:
- Manual tests were conducted to ensure that the reset button clears only the user's input in the practice questions mode and reloads the content correctly in the lessons mode.
- Verified that the question text persists in the editor as a comment, facilitating ease of reference for users.

### Screenshots:
Attached are screenshots demonstrating the before and after states of the editor for both practice questions and lessons.
Before:
<img width="905" alt="image" src="https://github.com/user-attachments/assets/cdcfb821-91ce-446e-8d5a-b5faf374500f">

After: 
<img width="922" alt="image" src="https://github.com/user-attachments/assets/f707e352-3049-433f-b8f9-c3159aa322fe">

### Steps to Test:
1. Navigate to a practice question, write some code in the editor, and press the reset button.
2. Observe that the written code is cleared but the question remains as a comment.
3. Load a lesson, modify the default code, and press the reset button to ensure the original content is restored.

@codingkatty Please review the changes and provide any feedback or approvals as necessary.